### PR TITLE
Removed download and install option from README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,28 +49,20 @@ Dependencies
 
 .. _`Scipy`: http://www.scipy.org/install.html
 
-Install dependencies:
+Clone & Install
+---------------
 
 ::
 
-    pip install -r requirements.txt
+    Clone the repository:
+        git clone https://github.com/libindic/indictrans.git
+        ------------------------OR--------------------------
+        git clone https://github.com/irshadbhat/indictrans.git
 
-Download
-~~~~~~~~
-
-Download **indictrans**  from `github`_.
-
-.. _`github`: https://github.com/libindic/indic-trans
-
-Install
-~~~~~~~
-
-::
-
-    pip install git+git://github.com/irshadbhat/indic-trans.git
-    ----------------------------OR-----------------------------
-    pip install git+git://github.com/libindic/indic-trans.git    
-
+    Change to the cloned directory:
+        cd indic-trans
+        pip install -r requirements.txt
+        python setup.py install
 
 Examples
 --------

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Installation
 ------------
 
 Dependencies
-~~~~~~~~~~~~
+^^^^^^^^^^^^
 
 `indictrans`_ requires `cython`_, and `SciPy`_.
 
@@ -50,7 +50,7 @@ Dependencies
 .. _`Scipy`: http://www.scipy.org/install.html
 
 Clone & Install
----------------
+^^^^^^^^^^^^^^^
 
 ::
 
@@ -68,7 +68,7 @@ Examples
 --------
 
 1. From Console:
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
 .. parsed-literal::
 
@@ -99,7 +99,7 @@ If the input text contains repeating words, which raw text generally does, make 
 Note that ``ml`` and ``rb`` are mutually exclusive arguments. If none of these is set, then the sytem defaults to ``rb``.
 
 2. Using Python:
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
 .. code:: python
 
@@ -133,7 +133,7 @@ Note that ``ml`` and ``rb`` are mutually exclusive arguments. If none of these i
     >>>
 
 3. K-Best Transliterations
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: python
 

--- a/docs/guide_installation.rst
+++ b/docs/guide_installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 Dependencies
-~~~~~~~~~~~~
+------------
 
 `indictrans`_ requires `cython`_, and `SciPy`_.
 
@@ -12,34 +12,9 @@ Dependencies
 
 .. _`Scipy`: http://www.scipy.org/install.html
 
-Install dependencies:
----------------------
 
-::
-
-    pip install -r requirements.txt
-
-
-Download
-~~~~~~~~
-
-Download **indictrans**  from `github`_.
-
-.. _`github`: https://github.com/libindic/indic-trans
-
-
-Direct Install
-~~~~~~~~~~~~~~
-
-::
-
-    pip install git+git://github.com/irshadbhat/indic-trans.git
-    ----------------------------OR-----------------------------
-    pip install git+git://github.com/libindic/indic-trans.git    
-
-
-Clone and Install
-~~~~~~~~~~~~~~~~~
+Clone & Install
+---------------
 
 ::
 
@@ -47,9 +22,8 @@ Clone and Install
         git clone https://github.com/libindic/indictrans.git
         ------------------------OR--------------------------
         git clone https://github.com/irshadbhat/indictrans.git
+
     Change to the cloned directory:
-        cd indictrans
-    Run setup.py to create installable source:
-        python setup.py sdist
-    Install using pip:
-        pip install dist/indictrans*.tar.gz
+        cd indic-trans
+        pip install -r requirements.txt
+        python setup.py install

--- a/docs/guide_model.rst
+++ b/docs/guide_model.rst
@@ -10,15 +10,15 @@ Assuming your data is in ``tnt`` format you can encode the data ane train a :cla
 
 .. code-block:: python
 
-    from indictrans import trunk
-    #load trianing data
-    X, y = trunk.load_data('indictrans/trunk/tests/hin2rom.tnt')
-    #build ngram-context
-    X = trunk.build_context(X, ngram=4)
-    #fit encoder
-    enc, X = trunk.fit_encoder(X)
-    #train structured-perceptron model
-    clf = trunk.train_sp(X, y, n_iter=5, verbose=2)
+    >>> from indictrans import trunk
+    >>> #load trianing data
+    ... X, y = trunk.load_data('indictrans/trunk/tests/hin2rom.tnt')
+    >>> #build ngram-context
+    ... X = trunk.build_context(X, ngram=4)
+    >>> #fit encoder
+    ... enc, X = trunk.fit_encoder(X)
+    >>> #train structured-perceptron model
+    ... clf = trunk.train_sp(X, y, n_iter=5, verbose=2)
     Iteration 1 ...
     Train-set error = 1.5490
     Iteration 2 ...
@@ -35,15 +35,15 @@ Then you can use the trained classifier as follows:
 
 .. code-block:: python
 
-    #load testing data
-    X_test, y = trunk.load_data('indictrans/trunk/tests/hin2rom.tnt')
-    #build ngram-context for testing data
-    X_test = trunk.build_context(X_test, ngram=4) # ngram value should be same as for train-set
-    #encode test-set
-    X_test = [enc.transform(x) for x in X_test]
-    #predict output sequences
-    y_ = clf.predict(X_test)
-    y[10]  # True
+    >>> #load testing data
+    ... X_test, y = trunk.load_data('indictrans/trunk/tests/hin2rom.tnt')
+    >>> #build ngram-context for testing data
+    ... X_test = trunk.build_context(X_test, ngram=4) # ngram value should be same as for train-set
+    >>> #encode test-set
+    ... X_test = [enc.transform(x) for x in X_test]
+    >>> #predict output sequences
+    ... y_ = clf.predict(X_test)
+    >>> y[10]  # True
     [u'c', u'l', u'a', u'ne', u'_']
     >>> y_[10]  # Predicted
     [u'c', u'l', u'a', u'n', u'_']

--- a/docs/guide_model.rst
+++ b/docs/guide_model.rst
@@ -8,7 +8,7 @@ Train and Test
 
 Assuming your data is in ``tnt`` format you can encode the data ane train a :class:`indictrans.trunk.StructuredPerceptron` classifier.
 
-.. code:: python
+.. code-block:: python
 
     from indictrans import trunk
     #load trianing data
@@ -33,7 +33,7 @@ This will train the perceptron for 5 epochs (specified via the ``n_iter`` parame
 
 Then you can use the trained classifier as follows:
 
-.. code:: python
+.. code-block:: python
 
     #load testing data
     X_test, y = trunk.load_data('indictrans/trunk/tests/hin2rom.tnt')
@@ -61,7 +61,7 @@ Train directly from Console
 
 `indictrans-trunk` provides a much easier way to train, test and save models directly from console.
 
-.. parsed-literal::
+.. code-block:: bash
 
     user@indic-trans$ indictrans-trunk --help
 

--- a/docs/guide_transliteration.rst
+++ b/docs/guide_transliteration.rst
@@ -8,10 +8,8 @@ Transliterate
 
 In order to transliterate raw text, you can use the :class:`indictrans.Transliterator` which uses already trained models to transliterate the text. If the input text contains repeating words, which raw text generally does, make sure to set ``build_lookup`` flag to ``True``. As the name indicates this builds lookup for transliterated words and thus avoids repeated transliteration of same words. This saves a lot of time if the input corpus is too big. 
 
-.. code:: python
+.. code-block:: python
 
-    Python 2.7.6
-    [GCC 4.8.2] on linux2
     from indictrans import Transliterator
     trn = Transliterator(source='hin', target='eng', build_lookup=True)
     hin = """कांग्रेस पार्टी अध्यक्ष सोनिया गांधी, तमिलनाडु की मुख्यमंत्री
@@ -40,10 +38,8 @@ K-Best Transliterations
 
 You can generate ``k-best`` outputs for a given sequence by changing the default decoder ``viterbi`` to ``beamsearch`` and then set the ``k_best`` parameter to the desired value.
 
-.. code:: python
+.. code-block:: python
     
-    Python 2.7.6
-    [GCC 4.8.2] on linux2
     from indictrans import Transliterator
     r2i = Transliterator(source='eng', target='mal', decode='beamsearch')
     words = '''sereleskar morocco calendar bhagyalakshmi bhoolokanathan medical
@@ -68,10 +64,8 @@ ML and Rule-Based systems for Indic Scripts
 
 For Indic scripts except Urdu you can use rule-based as well as machine learning (ML) system for transliteration. Rule based systems are very fast than ML systems and seem more accurate too. But for some language pairs ML systems generates better results.
 
-.. code:: python
+.. code-block:: python
 
-    Python 3.4.3
-    [GCC 4.8.4] on linux
     >>> from indictrans import Transliterator
     >>> rom_text = 'indictrans libindic hyderabad university bhagyalakshmi bharat morocco'.split()
     >>> r2h = Transliterator(source='eng', target='hin')
@@ -102,7 +96,7 @@ Transliterate from Console
 
 You can transliterate text files directly using the console shortcut ``indictrans``.
 
-.. parsed-literal::
+.. code-block:: bash
 
     $ indictrans --h
 

--- a/docs/guide_transliteration.rst
+++ b/docs/guide_transliteration.rst
@@ -10,23 +10,23 @@ In order to transliterate raw text, you can use the :class:`indictrans.Translite
 
 .. code-block:: python
 
-    from indictrans import Transliterator
-    trn = Transliterator(source='hin', target='eng', build_lookup=True)
-    hin = """कांग्रेस पार्टी अध्यक्ष सोनिया गांधी, तमिलनाडु की मुख्यमंत्री
-    जयललिता और रिज़र्व बैंक के गवर्नर रघुराम राजन के बीच एक समानता
-    है. ये सभी अलग-अलग कारणों से भारतीय जनता पार्टी के राज्यसभा सांसद
-    सुब्रमण्यम स्वामी के निशाने पर हैं. उनके जयललिता और सोनिया गांधी के
-    पीछे पड़ने का कारण कथित भ्रष्टाचार है."""
-    eng = trn.transform(hin)
-    print(eng)
+    >>> from indictrans import Transliterator
+    >>> trn = Transliterator(source='hin', target='eng', build_lookup=True)
+    >>> hin = """कांग्रेस पार्टी अध्यक्ष सोनिया गांधी, तमिलनाडु की मुख्यमंत्री
+    ... जयललिता और रिज़र्व बैंक के गवर्नर रघुराम राजन के बीच एक समानता
+    ... है. ये सभी अलग-अलग कारणों से भारतीय जनता पार्टी के राज्यसभा सांसद
+    ... सुब्रमण्यम स्वामी के निशाने पर हैं. उनके जयललिता और सोनिया गांधी के
+    ... पीछे पड़ने का कारण कथित भ्रष्टाचार है."""
+    >>> eng = trn.transform(hin)
+    >>> print(eng)
     congress party adhyaksh sonia gandhi, tamilnadu kii mukhyamantri
     jayalalita our reserve baink ke governor raghuram rajan ke beech ek samanta
     hai. ye sabi alag-alag carnon se bharatiya janata party ke rajyasabha saansad
     subramanyam swami ke nishane par hain. unke jayalalita our sonia gandhi ke
     peeche padane ka kaaran kathith bhrashtachar hai.
-    trn = Transliterator(source='eng', target='hin')
-    hin_ = trn.transform(eng)
-    print(hin_)
+    >>> trn = Transliterator(source='eng', target='hin')
+    >>> hin_ = trn.transform(eng)
+    >>> print(hin_)
     कांग्रेस पार्टी अध्यक्ष सोनिया गांधी, तमिलनाडु की मुख्यमांत्री
     जयललिता और रिज़र्व बैंक के गवर्नर रघुराम राजन के बीच एक समानता
     है. ये सभी अलग-अलग कार्नों से भारतीय जनता पार्टी के राज्यसभा संसद
@@ -40,12 +40,12 @@ You can generate ``k-best`` outputs for a given sequence by changing the default
 
 .. code-block:: python
     
-    from indictrans import Transliterator
-    r2i = Transliterator(source='eng', target='mal', decode='beamsearch')
-    words = '''sereleskar morocco calendar bhagyalakshmi bhoolokanathan medical
-            ernakulam kilometer vitamin management university naukuchiatal'''.split()
-    for word in words:
-        print('%s -> %s' % (word, '  '.join(r2i.transform(word, k_best=5))))
+    >>> from indictrans import Transliterator
+    >>> r2i = Transliterator(source='eng', target='mal', decode='beamsearch')
+    >>> words = '''sereleskar morocco calendar bhagyalakshmi bhoolokanathan medical
+    ...         ernakulam kilometer vitamin management university naukuchiatal'''.split()
+    >>> for word in words:
+    >>>     print('%s -> %s' % (word, '  '.join(r2i.transform(word, k_best=5))))
     sereleskar -> സേറെലേസ്കാര്  സെറെലേസ്കാര്  സേറെലേസ്കാര  സെറെലേസ്കാര  സേറെലേസ്കര്
     morocco -> മൊറോക്കോ  മൊറോക്ഡോ  മൊരോക്കോ  മോറോക്കോ  മൊറോക്കൂ
     calendar -> കേലെന്ദര  കേലെന്ഡര  കേലെന്ദ്ര  കേലെന്ദാര  കേലെന്ഡ്ര


### PR DESCRIPTION
It seems like pbr fails to setup without git meta-data. So one is bound to clone and install only.

Fixed some issues in docs.

Regarding big-files (trained transliteration models) in the repo:
Size on downloading: 322M before unzip and 1GB after unzip.
Size on cloning: 1.6GB

The clone size is more because of various versions of big model files and this can further grow on any model update. This can be avoided if we migrate these big-files to ``git-lfs`` files. Git-Lfs replaces large files with text pointers inside Git, while storing the file contents on a remote server. ``git-lfs`` allows us to store only pointers to each version of the file in the repository, hence each clone will only download a tiny piece of data for each revision. The cloner gets only the version we are using. As a result, we would be using disk space on the server, but saving a lot of bandwidth and disk space on the cloner-side.

I recently worked with ``git-lfs`` on [this](https://github.com/iscnlp/iscnlp) repo. But I used ``git-lfs`` from the first push itself. I don't have much idea about converting an an existing Git repo to support LFS and it looks complicated as well. [Here](https://github.com/github/git-lfs/issues/326) is a post regarding migrating an existing Git repo to support LFS. I will try to work it out. Hope it works.