### PR TITLE
Add pyproject.toml for build-system environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython", "numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
The `setup.py` itself seems to require `Cython` and `numpy` as pre-requisite, because of which `pip install git+https://github.com/libindic/indic-trans` fails on new machines.

It works now after the patch in this PR. ([More details](https://stackoverflow.com/a/54304732))